### PR TITLE
Pluralization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > Minimalistic I18n library for Ruby
 
-`MiniI18n` is a simple and flexible Ruby Internationalization library. It supports interpolations, fallbacks, nested keys and more.
+`MiniI18n` is a simple and flexible Ruby Internationalization library. It supports interpolations, pluralization, fallbacks, nested keys and more.
 
 Translations should be stored in YAML files and they will loaded in a in-memory `Hash`.
 
@@ -108,7 +108,18 @@ It accepts the following options:
 => "default value"
 ```
 
-It also accepts interpolation:
+* `count`
+
+Read more details in the [Pluralization section](#pluralization).
+
+```ruby
+>> MiniI18n.t('notifications', count: 0)
+=> "no unread notifications"
+```
+
+### Interpolation
+
+You can also use variables in your translation definitions:
 
 ```yaml
 en:
@@ -118,6 +129,29 @@ en:
 ```ruby
 >> MiniI18n.t(:hello_with_name, name: 'John Doe')
 => "Hello John Doe!"
+```
+
+### Pluralization
+
+You should define your plurals in the following format:
+
+```yaml
+en:
+  notifications:
+    zero: 'no unread notifications'
+    one: '1 unread notification'
+    many: '%{count} unread notifications'
+```
+
+Then, you should call the method with the `count` option:
+
+```ruby
+>> MiniI18n.t('notifications', count: 0)
+=> "no unread notifications"
+>> MiniI18n.t('notifications', count: 1)
+=> "1 unread notification"
+>> MiniI18n.t('notifications', count: 5)
+=> "5 unread notifications"
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ en:
 
 ### Pluralization
 
-You should define your plurals in the following format:
+You should define your plurals in the following format (supported keys: `zero`, `one` and `many`):
 
 ```yaml
 en:

--- a/lib/mini_i18n.rb
+++ b/lib/mini_i18n.rb
@@ -72,11 +72,11 @@ module MiniI18n
       keys << key.to_s.split(SEPARATOR)
       keys = keys.flatten
 
-      result = translations.dig(*keys)
+      result = lookup(*keys)
 
       if fallbacks && result.empty?
         keys = Utils.replace_with(keys, _locale, default_locale.to_s)
-        result = translations.dig(*keys)
+        result = lookup(*keys)
       end
 
       if count && result.is_a?(Hash)
@@ -111,6 +111,10 @@ module MiniI18n
     def available_locale?(new_locale)
       new_locale = new_locale.to_s
       available_locales.include?(new_locale) && new_locale
+    end
+
+    def lookup(*keys)
+      translations.dig(*keys)
     end
   end
 end

--- a/lib/mini_i18n.rb
+++ b/lib/mini_i18n.rb
@@ -65,6 +65,7 @@ module MiniI18n
 
       _locale = available_locale?(options[:locale]) || locale
       scope = options[:scope]
+      count = options[:count]
 
       keys = [_locale.to_s]
       keys << scope.to_s.split(SEPARATOR) if scope
@@ -76,6 +77,17 @@ module MiniI18n
       if fallbacks && result.empty?
         keys = Utils.replace_with(keys, _locale, default_locale.to_s)
         result = translations.dig(*keys)
+      end
+
+      if count && result.is_a?(Hash)
+        case count
+        when 0
+          result = result["zero"]
+        when 1
+          result = result["one"]
+        else
+          result = result["many"]
+        end
       end
 
       if result.respond_to?(:match) && result.match(/%{\w+}/)

--- a/spec/fixtures/locales/en.yml
+++ b/spec/fixtures/locales/en.yml
@@ -4,3 +4,7 @@ en:
   fallback: "fallback"
   second_level:
     hello: ""
+  notifications:
+    zero: 'no unread notifications'
+    one: '1 unread notification'
+    many: '%{count} unread notifications'

--- a/spec/mini_i18n_spec.rb
+++ b/spec/mini_i18n_spec.rb
@@ -85,5 +85,11 @@ RSpec.describe MiniI18n do
       MiniI18n.fallbacks = true
       expect(MiniI18n.t('fallback', locale: :es)).to eq 'fallback'
     end
+
+    it "pluralization" do
+      expect(MiniI18n.t('notifications', count: 0)).to eq 'no unread notifications'
+      expect(MiniI18n.t('notifications', count: 1)).to eq '1 unread notification'
+      expect(MiniI18n.t('notifications', count: 2)).to eq '2 unread notifications'
+    end
   end
 end


### PR DESCRIPTION

```yaml
notifications:
  zero: 'no unread notifications'
  one: '1 unread notification'
  many: '%{count} unread notifications'
```

 ```ruby
>> MiniI18n.t('notifications', count: 0)
=> "no unread notifications"
>> MiniI18n.t('notifications', count: 1)
=> "1 unread notification"
>> MiniI18n.t('notifications', count: 5)
=> "5 unread notifications"
```