### PR TITLE
Fix CI

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,1 @@
---format documentation
---color
 --require spec_helper

--- a/lib/mini_i18n.rb
+++ b/lib/mini_i18n.rb
@@ -63,6 +63,7 @@ module MiniI18n
 
     def load_translations(path)
       Dir[path.to_s].each do |file|
+        puts file
         YAML.load_file(file).each do |locale, new_translations|
           add_translations(locale.to_s, new_translations)
         end

--- a/lib/mini_i18n.rb
+++ b/lib/mini_i18n.rb
@@ -62,8 +62,7 @@ module MiniI18n
     end
 
     def load_translations(path)
-      Dir[path.to_s].each do |file|
-        puts file
+      Dir[path.to_s].sort.each do |file|
         YAML.load_file(file).each do |locale, new_translations|
           add_translations(locale.to_s, new_translations)
         end


### PR DESCRIPTION
`Dir#glob` doesn't sort entries by default in Ruby 2.X